### PR TITLE
Fix white- and blacklist config via docker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2.0.1
+
+* Fix white- and blacklist config via docker env where and empty string resulted in a pass-all regex overwriting the blacklist.
+
 ## 2.0.0
 
 * Rework of the complete structure, but no functional changes.

--- a/docker2mqtt/__init__.py
+++ b/docker2mqtt/__init__.py
@@ -1,6 +1,6 @@
 """docker2mqtt package."""
 
-__VERSION__ = "2.0.0"
+__VERSION__ = "2.0.1"
 
 from .const import (
     ANSI_ESCAPE,

--- a/docker2mqtt/__main__.py
+++ b/docker2mqtt/__main__.py
@@ -31,6 +31,9 @@ main_logger = logging.getLogger("main")
 if __name__ == "__main__":
     # Env config
 
+    whitelist = environ.get("CONTAINER_WHITELIST", "")
+    blacklist = environ.get("CONTAINER_BLACKLIST", "")
+
     cfg = Docker2MqttConfig(
         {
             "log_level": environ.get("LOG_LEVEL", LOG_LEVEL_DEFAULT),
@@ -53,10 +56,8 @@ if __name__ == "__main__":
                 "MQTT_TOPIC_PREFIX", MQTT_TOPIC_PREFIX_DEFAULT
             ),
             "mqtt_qos": int(environ.get("MQTT_QOS", MQTT_QOS_DEFAULT)),
-            "container_whitelist": environ.get("CONTAINER_WHITELIST", "").split(",")
-            or [],
-            "container_blacklist": environ.get("CONTAINER_BLACKLIST", "").split(",")
-            or [],
+            "container_whitelist": whitelist.split(",") if len(whitelist) > 0 else [],
+            "container_blacklist": blacklist.split(",") if len(blacklist) > 0 else [],
             "enable_events": bool(environ.get("EVENTS", EVENTS_DEFAULT)),
             "enable_stats": bool(environ.get("STATS", STATS_DEFAULT)),
             "stats_record_seconds": int(

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = docker2mqtt
-version = 2.0.0
+version = 2.0.1
 author = Cyrill Raccaud
 author_email = cyrill.raccaud+pypi@gmail.com
 description = Send your docker stats and and events to mqtt and discovery them in home assistant.


### PR DESCRIPTION
Fix white- and blacklist config via docker env where and empty string resulted in a pass-all regex overwriting the blacklist.

When running with docker, before it extracted the white- and blacklists like that `os.environ.get("CONTAINER_WHITELIST", "").split(",") or []`, resulting in `[""]` for an empty environment value. Now it correctly becomes an empty list which will be correctly ignored instead of bypassing the blacklist. Same for the blacklist, where a block-all would happen for a list like `[""]`.