### PR TITLE
fix the mqtt port arg type to int

### DIFF
--- a/docker2mqtt/docker2mqtt.py
+++ b/docker2mqtt/docker2mqtt.py
@@ -1196,6 +1196,7 @@ def main() -> None:
     parser.add_argument(
         "--port",
         default=MQTT_PORT_DEFAULT,
+        type=int,
         help="Port or IP address of the MQTT broker (default: 1883)",
     )
     parser.add_argument(


### PR DESCRIPTION
The port needs to be of type `int` instead of `str` for the paho mqtt lib.