### PR TITLE
Add container host to MQTT events

### DIFF
--- a/docker2mqtt/docker2mqtt.py
+++ b/docker2mqtt/docker2mqtt.py
@@ -254,6 +254,7 @@ class Docker2Mqtt:
                         {
                             "name": container_status["Names"],
                             "image": container_status["Image"],
+                            "host": cfg['docker2mqtt_hostname'],
                             "status": status_str,
                             "state": state_str,
                         }

--- a/docker2mqtt/type_definitions.py
+++ b/docker2mqtt/type_definitions.py
@@ -82,6 +82,8 @@ class ContainerEvent(TypedDict):
         The name of the container
     image
         The image the container is running
+    host
+        The host the container is running on
     status
         The docker status the container is in
     state
@@ -91,6 +93,7 @@ class ContainerEvent(TypedDict):
 
     name: str
     image: str
+    host: str | None
     status: ContainerEventStatusType
     state: ContainerEventStateType
 

--- a/docker2mqtt/type_definitions.py
+++ b/docker2mqtt/type_definitions.py
@@ -93,7 +93,7 @@ class ContainerEvent(TypedDict):
 
     name: str
     image: str
-    host: str | None
+    host: str
     status: ContainerEventStatusType
     state: ContainerEventStateType
 


### PR DESCRIPTION
Hope it's okay to open a pull request against your repo. This change is to add the container host to the MQTT events so it appears as an attribute in Homeassistant so its a bit easier to tell which containers are running where...